### PR TITLE
refactor: use of placeholders for logging

### DIFF
--- a/jackson-json-reference-cli/src/main/java/me/andrz/jackson/JsonReferenceCli.java
+++ b/jackson-json-reference-cli/src/main/java/me/andrz/jackson/JsonReferenceCli.java
@@ -2,7 +2,6 @@ package me.andrz.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.apache.commons.cli.*;
 

--- a/jackson-json-reference-cli/src/test/java/me/andrz/jackson/JsonReferenceCliTest.java
+++ b/jackson-json-reference-cli/src/test/java/me/andrz/jackson/JsonReferenceCliTest.java
@@ -2,8 +2,6 @@ package me.andrz.jackson;
 
 import org.junit.Test;
 
-import java.io.File;
-
 /**
  * Created by anders on 11/21/15.
  */

--- a/jackson-json-reference-core/src/main/java/me/andrz/jackson/JsonContext.java
+++ b/jackson-json-reference-core/src/main/java/me/andrz/jackson/JsonContext.java
@@ -3,7 +3,6 @@ package me.andrz.jackson;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.MissingNode;
 
 import java.io.File;
 import java.io.IOException;

--- a/jackson-json-reference-core/src/main/java/me/andrz/jackson/JsonReferenceProcessor.java
+++ b/jackson-json-reference-core/src/main/java/me/andrz/jackson/JsonReferenceProcessor.java
@@ -142,12 +142,12 @@ public class JsonReferenceProcessor {
             context.setProcessed(new HashSet<JsonReference>());
         }
 
-        logger.trace("processed: " + context.getProcessed());
+        logger.trace("processed: {}", context.getProcessed());
 
         // Check if the whole node must be replaced
         if (JsonReferenceNode.is(node)) {
             JsonNode replacementNode = getReplacementNode(node, context);
-            logger.debug("replacing whole node with" + replacementNode);
+            logger.debug("replacing whole node with {}", replacementNode);
             return replacementNode;
         }
 
@@ -162,16 +162,16 @@ public class JsonReferenceProcessor {
             while (elements.hasNext()) {
                 JsonNode subNode = elements.next();
 
-                logger.trace("i=" + i);
+                logger.trace("i={}", i);
 
                 if (JsonReferenceNode.is(subNode)) {
 
                     JsonNode replacementNode = getReplacementNode(subNode, context);
                     if (replacementNode == null) {
-                        logger.info("Got null replacement node on position " + i);
+                        logger.info("Got null replacement node on position {}", i);
                         continue;
                     }
-                    logger.debug("replacing " + "subNode" + " with " + replacementNode);
+                    logger.debug("replacing subNode with {}", replacementNode);
                     arrayNode.set(i, replacementNode);
                    
                 } else {
@@ -188,16 +188,16 @@ public class JsonReferenceProcessor {
                 String key = field.getKey();
                 JsonNode subNode = field.getValue();
 
-                logger.trace("key=" + key);
+                logger.trace("key={}", key);
 
                 if (JsonReferenceNode.is(subNode)) {
 
                     JsonNode replacementNode = getReplacementNode(subNode, context);
                     if (replacementNode == null) {
-                        logger.info("Got null replacement node for key " + key);
+                        logger.info("Got null replacement node for key {}", key);
                         continue;
                     }
-                    logger.debug("replacing " + "subNode" + " with " + replacementNode);
+                    logger.debug("replacing subNode with {}", replacementNode);
                     objectNode.set(key, replacementNode);
                 } else {
                     process(context, subNode);
@@ -219,7 +219,7 @@ public class JsonReferenceProcessor {
         }
 
         if (stopOnCircular && processed.contains(absRef)) {
-            logger.debug("skipping on ref: " + absRef);
+            logger.debug("skipping on ref: {}", absRef);
             return null;
         }
         // add ref to processed set for detection loop in recursion
@@ -252,7 +252,7 @@ public class JsonReferenceProcessor {
         URL absoluteReferencedUrl;
         URI refUri = ref.getUri();
 
-        logger.debug("dereferencing " + ref);
+        logger.debug("dereferencing {}", ref);
 
         if (ref.isLocal()) {
             absoluteReferencedUrl = context.getUrl();
@@ -317,7 +317,7 @@ public class JsonReferenceProcessor {
             throw new JsonReferenceException("Cannot cache null object.");
         }
         if (cacheInMemory && !cache.contains(any)) {
-            logger.debug("Putting into the cache: " + any);
+            logger.debug("Putting into the cache: {}", any);
             URL url;
             if (any instanceof URL) {
                 url = (URL) any;


### PR DESCRIPTION
This changes the way parameters are passed to form logging messages to use placeholders `{}`. By using placeholders the arguments to logging framework are not converted to String via (`toString`) and concatenated.

This decreases memory and processing cost by not accumulating memory in String concatenation and invoking `toString` -- which in case of Jackson, on ObjectNode classes leads to serialization to JSON.

Ref https://www.slf4j.org/faq.html#logging_performance